### PR TITLE
Fix for COS mashup paging

### DIFF
--- a/Board Classes Of Services/BoardClassOfServices.js
+++ b/Board Classes Of Services/BoardClassOfServices.js
@@ -57,7 +57,7 @@ tau.mashups
 					whereIdsStr = '0';
 				}
 
-                var requestUrl = configurator.getApplicationPath() + '/api/v2/Assignable?take=1000&where=TagObjects.Count('+whereTagStr+')>0 or (id in ['+whereIdsStr+'] and EntityState.isFinal==false)&select={id,Tags,EntityState.Name as state,Priority.Name as priority}&acid=' + acid;
+                var requestUrl = configurator.getApplicationPath() + '/api/v2/Assignable?take=1000&where=TagObjects.Count('+whereTagStr+')>0 and (id in ['+whereIdsStr+'] and EntityState.isFinal==false)&select={id,Tags,EntityState.Name as state,Priority.Name as priority}&acid=' + acid;
                 $.ajax({
                     url: requestUrl,
                     context: this


### PR DESCRIPTION
Proposed fix for paging issues with the Classes of Service mashup.  I think the logic was off for the filter for the API call.  The _or_ in there right now causes the `Tags.Count > 0` to bring back all records that have tags, regardless of their presence on the board or not.  This may bring back thousands of records that aren't on the board and limit the amount of records we get for items that actually are.
