### PR TITLE
Fix for BV/state coloring with COS mashup

### DIFF
--- a/Board Classes Of Services/BoardClassOfServices.js
+++ b/Board Classes Of Services/BoardClassOfServices.js
@@ -50,14 +50,13 @@ tau.mashups
 			this.refresh = function(ctx) {
 
 				var acid = ctx.acid;
-                var whereTagStr = this.getFilter(this.tagMapping);
 				var whereIdsStr = this.cards.map($.proxy(function(c){ return this._getCardId(c); }, this)).join(',');
 
 				if (whereIdsStr == '') {
 					whereIdsStr = '0';
 				}
 
-                var requestUrl = configurator.getApplicationPath() + '/api/v2/Assignable?take=1000&where=TagObjects.Count('+whereTagStr+')>0 and (id in ['+whereIdsStr+'] and EntityState.isFinal==false)&select={id,Tags,EntityState.Name as state,Priority.Name as priority}&acid=' + acid;
+                var requestUrl = configurator.getApplicationPath() + '/api/v2/Assignable?take=1000&where=(id in ['+whereIdsStr+'] and EntityState.isFinal==false)&select={id,Tags,EntityState.Name as state,Priority.Name as priority}&acid=' + acid;
                 $.ajax({
                     url: requestUrl,
                     context: this
@@ -105,14 +104,6 @@ tau.mashups
                 $.each(this.cards, function(index, card) {
                     self.renderCard(card);
                 });
-            };
-
-            this.getFilter = function(mapping){
-                var where = [];
-                $.each(mapping, function(tag, color){
-                    where.push('Name=="'+ tag +'"');
-                });
-                return where.join(" or ");
             };
         }
 


### PR DESCRIPTION
This pull request removes the tag filtering on the REST API call for the COS mashup.  This fixes the BV/state coloring issues, but brings back the possibility of paging being a problem (whereas only the first 1000 cards will properly be colored).  For boards smaller than 1000 cards, this isn't an issue.  Fixes #15
