### PR TITLE
Added Description Entity Linker

### DIFF
--- a/Description Entity Linker/DescriptionEntityLinker.cfg
+++ b/Description Entity Linker/DescriptionEntityLinker.cfg
@@ -1,0 +1,1 @@
+﻿Placeholders:footerPlaceholder

--- a/Description Entity Linker/DescriptionEntityLinker.js
+++ b/Description Entity Linker/DescriptionEntityLinker.js
@@ -1,0 +1,44 @@
+tau.mashups
+.addDependency(	'tp/userStory/view')
+.addDependency('tp/task/view')
+.addDependency('tp/request/view')
+.addDependency('tp/bug/view')
+.addDependency("jQuery")
+.addMashup(function(storyView, taskView, requestView, bugView, $, config) {
+
+	function renderTagLinks() {
+		setTimeout(function() {
+			var capture = /#(\d+)/.exec($("div.ui-description__inner:not('.linkz0red')").html());
+			$("div.ui-description__inner").addClass('linkz0red');
+			if (capture != null) {
+				var id = capture[1];
+				$.getJSON(
+					'/api/v1/Generals/{0}?include=[EntityType]&format=json'.f(id), 
+					function(resp){
+						$("div.ui-description__inner").html(
+							$("div.ui-description__inner").html().replace(
+								/#(\d+)/,
+								"<a href='#{0}/{1}'>#$1</a>".f(resp.EntityType.Name.toLowerCase(), resp.Id)
+								)
+							);
+					});
+			}
+		},1000);
+	}
+
+	$(document).ready(renderTagLinks);
+
+	storyView.onRender(renderTagLinks);
+	taskView.onRender(renderTagLinks);
+	requestView.onRender(renderTagLinks);
+	bugView.onRender(renderTagLinks);
+}
+);
+
+/* my new favorite proto function */
+String.prototype.f = function() {
+	var s = this, i = arguments.length;
+	while (i--)
+		s = s.replace(new RegExp('\\{' + i + '\\}', 'gm'), arguments[i]);
+	return s;
+};

--- a/Description Entity Linker/README.mkd
+++ b/Description Entity Linker/README.mkd
@@ -1,0 +1,15 @@
+Description Entity Linker
+=========================
+
+The Description Entity Linker Mashup is a Mashup for [TargetProcess 3](http://www.targetprocess.com/3) that allows you to 
+link to other entities in TargetProcess in the description text.  Simply put `#(entity ID)` in the description text (for example: `#208`) will create a link to that entity the next time the text is displayed.
+
+Installing the Mashup with TargetProcess 3 on demand
+----------------------------------------------------
+
+1. In your TP site, navigate to ```Settings > (System Settings) > Mashups```
+2. Click "Add New Mashup"
+3. In the "Name" field, enter "Description Entity Linker"
+4. In the "Placeholders" field, enter ```footerPlaceholder```
+5. Copy and paste the contents of the [DescriptionEntityLinker.js](https://raw.github.com/TargetProcess/TP3MashupLibrary/master/Description%20Entity%20Linker/DescriptionEntityLinker.js) file in the "Code" box.
+6. Click Save


### PR DESCRIPTION
Added a mashup to link to entites by typing #(entity id) in the description field, as suggested here: http://tp3.uservoice.com/forums/174654-targetprocess-we-will-rock-you-/suggestions/4039448-use-1234-syntax-to-create-quick-links-to-entities
