### PR TITLE
Fix for impending doom mashup crashing

### DIFF
--- a/Impending Doom/Impending Doom.js
+++ b/Impending Doom/Impending Doom.js
@@ -115,10 +115,12 @@ tau.mashups
 			};
 
             this.getCardColor = function(card) {
-                var process = card.Project.Process.Name.toLowerCase();
-                var processMap = _.find(DoomConfig, function(v,k) {
-                    return k.toLowerCase() == process;
-                });
+                if (card.Project) {
+                    var process = card.Project.Process.Name.toLowerCase();
+                    var processMap = _.find(DoomConfig, function(v,k) {
+                        return k.toLowerCase() == process;
+                    });
+                }
                 /* revert to our catch-all...if we've got one */
                 if ((processMap == undefined) && (DoomConfig['*'] != undefined)) {
                     processMap = DoomConfig['*'];


### PR DESCRIPTION
The impending doom mashup had an issue where it would throw a null exception during coloring.  The mashup expected all output from the API to have a `Project.Process` property - however items with no project would have `Project == null`.  This fix adds a null check to avoid crashing in this situation and, rather, continue coloring that card according to a global configuration as well as moving on to subsequent cards.
