### PR TITLE
Remove undefined values from resulting array

### DIFF
--- a/Custom Field Constraints/CFConstraints.quick.add.js
+++ b/Custom Field Constraints/CFConstraints.quick.add.js
@@ -110,7 +110,7 @@ tau.mashups
                     }),
                     cascadeCFs = this.cascadeTracker.buildCascadeCFs(calculatedRequiredCFs.concat(requiredCFs), data.customFields);
 
-                return calculatedRequiredCFs.concat(cascadeCFs);
+                return _.compact(calculatedRequiredCFs.concat(cascadeCFs));
             },
 
             _modifyBindData: function(dataBindEvtArg, requiredCFsToModify) {


### PR DESCRIPTION
Sometimes `_modifyBindData` fails with `TypeError: Cannot read property 'entityTypeName' of undefined` because one of array elements returned from `_buildRequiredCFsToModify` is `undefined` (requires further investigation).