### PR TITLE
BUG#100589 Custom field Constraints mashup doesn't work with Team States

### DIFF
--- a/Custom Field Constraints/CFConstraints.quick.add.js
+++ b/Custom Field Constraints/CFConstraints.quick.add.js
@@ -122,6 +122,13 @@ tau.mashups
             _createCFDataBindConfig: function(cf) {
                 return {
                     caption: cf.name,
+                    config: {
+                        calculationModel: '',
+                        calculationModelContainsCollections: null,
+                        defaultValue: '',
+                        resourceType: 'CustomFieldConfig',
+                        units: ''
+                    },
                     fieldType: cf.fieldType,
                     id: 'CustomFields',
                     options: cf.value ? {value: cf.value} : {},

--- a/Custom Field Constraints/CFConstraints.state.interrupter.js
+++ b/Custom Field Constraints/CFConstraints.state.interrupter.js
@@ -9,7 +9,12 @@ tau.mashups
             },
 
             _shouldChangeBeHandled: function(change) {
-                return change.name && change.name.toLowerCase() === 'entitystate';
+                return change.name &&
+                    _.contains(['entitystate', 'assignedteams', 'teamentitystate'], change.name.toLowerCase());
+            },
+
+            _isTeamStateChange: function(change) {
+                return change.name && _.contains(['assignedteams', 'teamentitystate'], change.name.toLowerCase());
             },
 
             _getEntityRequiredCFs: function(entityToRequire) {
@@ -17,21 +22,21 @@ tau.mashups
             },
 
             _buildEntitiesWithRequirements: function(entitiesDetailed, changesToHandle, defaultProcess) {
-                var entitiesToHandleDeferred = $.Deferred();
+                var teamProjectsPromise = this.dataProvider.getTeamProjectsPromise(entitiesDetailed);
+                var entityStatesDetailsPromise = this.dataProvider.getEntityStatesDetailsPromise(changesToHandle, entitiesDetailed, defaultProcess);
+                var tasksDetailsPromise = this.dataProvider.getTasksDetailsPromise(entitiesDetailed);
 
-                this.dataProvider.getEntityStatesDetailsPromise(changesToHandle, entitiesDetailed, defaultProcess).done(_.bind(function(entityStatesDetailed) {
-                    this.dataProvider.getTasksDetailsPromise(entitiesDetailed).done(_.bind(function(tasks) {
-                        this._getEntitiesWithRequirements(entitiesToHandleDeferred, entitiesDetailed, entityStatesDetailed, changesToHandle, defaultProcess, tasks);
-                    }, this))
-                }, this));
-
-                return entitiesToHandleDeferred.promise();
+                return $.when(teamProjectsPromise, entityStatesDetailsPromise, tasksDetailsPromise)
+                    .then(function(teamProjects, entityStatesDetailed, tasks) {
+                        return this._getEntitiesWithRequirements(entitiesDetailed, entityStatesDetailed, changesToHandle,
+                            defaultProcess, tasks, teamProjects);
+                    }.bind(this));
             },
 
-            _getEntitiesWithRequirements: function(entitiesToHandleDeferred, entitiesDetailed, entityStatesDetailed, changesToHandle, defaultProcess, tasks) {
+            _getEntitiesWithRequirements: function(entitiesDetailed, entityStatesDetailed, changesToHandle, defaultProcess, tasks, teamProjects) {
                 var entitiesToHandle = _.map(entitiesDetailed, function(entity) {
                     var entities = [],
-                        newState = this._getNewState(entity, entityStatesDetailed, changesToHandle, defaultProcess);
+                        newState = this._getNewState(entity, entityStatesDetailed, changesToHandle, defaultProcess, teamProjects);
 
                     if (newState){
                         var entityToHandle = {
@@ -52,8 +57,7 @@ tau.mashups
 
                     return entities;
                 }, this);
-
-                entitiesToHandleDeferred.resolve(_.flatten(entitiesToHandle, true));
+                return _.flatten(entitiesToHandle, true);
             },
 
             _getUserStoryTasksToHandle: function(entityToHandle, tasks, entityStatesDetailed, defaultProcess) {
@@ -84,7 +88,7 @@ tau.mashups
                 }, this);
             },
 
-            _getNewState: function(entity, entityStatesDetailed, changesToInterrupt, defaultProcess) {
+            _getNewState: function(entity, entityStatesDetailed, changesToInterrupt, defaultProcess, teamProjects) {
                 this._throwNotImplemented();
             }
         });

--- a/Custom Field Constraints/CFConstraints.state.interrupter.slice.js
+++ b/Custom Field Constraints/CFConstraints.state.interrupter.slice.js
@@ -21,7 +21,7 @@ tau.mashups
 
             _getNewState: function(entity, entityStatesDetailed, changesToInterrupt, defaultProcess, teamProjects) {
                 var entityStateChange = _.find(changesToInterrupt, function(change) {
-                    return parseInt(this.sliceDecoder.decode(change.id)) == entity.id;
+                    return parseInt(this.sliceDecoder.decode(change.id)) === entity.id;
                 }, this);
 
                 return this._getEntityState(entity, entityStatesDetailed, entityStateChange.changes, defaultProcess, teamProjects);
@@ -37,19 +37,15 @@ tau.mashups
                     return this._getTeamState(stateName, entity, entityStates, change, teamProjects);
                 } else {
                     return _.find(entityStates, function(state) {
-                        return state.process.id == this.dataProvider.getEntityProcessId(entity, defaultProcess)
-                            && state.entityType.name == entity.entityType.name
-                            && (stateName.toLowerCase() == state.name.toLowerCase()
-                                || (stateName.toLowerCase() == '_initial' && state.isInitial)
-                                || (stateName.toLowerCase() == '_final' && state.isFinal)
-                                || (stateName.toLowerCase() == '_planned' && state.isPlanned)
-                            )
+                        return state.process.id === this.dataProvider.getEntityProcessId(entity, defaultProcess)
+                            && state.entityType.name === entity.entityType.name
+                            && this.isStateEqual(stateName, state)
                     }, this);
                 }
             },
 
             _getTeamState: function(stateName, entity, entityStates, change, teamProjects) {
-                if (!entity.assignedTeams || entity.assignedTeams.length === 0) {
+                if (_.isEmpty(entity.assignedTeams)) {
                     return null;
                 }
                 var workflowIds = _.compact(_.map(entity.assignedTeams, function(teamAssignment) {
@@ -62,7 +58,7 @@ tau.mashups
                         return null;
                     }
                     return _.find(teamProject.workflows, function(workflow) {
-                        return workflow.entityType.name == entity.entityType.name;
+                        return workflow.entityType.name === entity.entityType.name;
                     }).id;
                 }));
                 return _.find(entityStates, function(state) {
@@ -76,12 +72,15 @@ tau.mashups
             },
 
             isProperState: function(stateName, state, workflowIds) {
-                return _.contains(workflowIds, state.workflow.id)
-                    && (stateName.toLowerCase() == state.name.toLowerCase()
-                        || (stateName.toLowerCase() == '_initial' && state.isInitial)
-                        || (stateName.toLowerCase() == '_final' && state.isFinal)
-                        || (stateName.toLowerCase() == '_planned' && state.isPlanned)
-                    )
+                return _.contains(workflowIds, state.workflow.id) && this.isStateEqual(stateName, state)
+            },
+
+            isStateEqual: function(expectedStateName, actualState) {
+                return (expectedStateName.toLowerCase() === actualState.name.toLowerCase()
+                    || (expectedStateName.toLowerCase() === '_initial' && actualState.isInitial)
+                    || (expectedStateName.toLowerCase() === '_final' && actualState.isFinal)
+                    || (expectedStateName.toLowerCase() === '_planned' && actualState.isPlanned)
+                );
             }
         });
 

--- a/Custom Field Constraints/CFConstraints.state.interrupter.store.js
+++ b/Custom Field Constraints/CFConstraints.state.interrupter.store.js
@@ -22,12 +22,34 @@ tau.mashups
                     }
                 );
 
-                var newStateId = _.find(entityStateChange.changes,function(change) {
+                var change = _.find(entityStateChange.changes, function(change) {
                     return this._shouldChangeBeHandled(change);
-                }, this).value.id;
+                }, this);
 
+                return this._getStateFromChange(entityStatesDetailed, change);
+            },
+
+            _getStateFromChange: function(entityStatesDetailed, change) {
+                if (this._isTeamStateChange(change)) {
+                    var value = change.value;
+                    if (_.isArray(value) && value.length === 1 && value[0].entityState) {
+                        return this._getTeamStateFromChange(entityStatesDetailed, value[0].entityState.id);
+                    } else {
+                        return null;
+                    }
+                } else {
+                    var newStateId = change.value.id;
+                    return _.find(entityStatesDetailed, function(state) {
+                        return state.id == newStateId;
+                    });
+                }
+            },
+
+            _getTeamStateFromChange: function(entityStatesDetailed, teamStateId) {
                 return _.find(entityStatesDetailed, function(state) {
-                    return state.id == newStateId;
+                    return _.some(state.subEntityStates, function(sub) {
+                        return sub.id === teamStateId;
+                    });
                 });
             }
         });

--- a/Custom Field Constraints/CFConstraints.state.interrupter.store.js
+++ b/Custom Field Constraints/CFConstraints.state.interrupter.store.js
@@ -18,7 +18,7 @@ tau.mashups
 
             _getNewState: function(entity, entityStatesDetailed, changesToInterrupt) {
                 var entityStateChange = _.find(changesToInterrupt, function(change) {
-                        return change.id == entity.id;
+                        return change.id === entity.id;
                     }
                 );
 
@@ -40,7 +40,7 @@ tau.mashups
                 } else {
                     var newStateId = change.value.id;
                     return _.find(entityStatesDetailed, function(state) {
-                        return state.id == newStateId;
+                        return state.id === newStateId;
                     });
                 }
             },


### PR DESCRIPTION
When user chooses team state and it's parent project state has constrains then we show constrain dialog. This functionality is supported on entity view with new state selector and view with TeamState axis.

Fix quick add on state axis for state value with constraints. Custom field template data has additional config section now

We do not support constraints for quick add on TeamState axis. It is too complicated with multiply functional teams