### PR TITLE
BUG#140352 Mashup 'IDs on TimeSheet' isn't applied to Time Sheet

### DIFF
--- a/IDs on Time Sheet/IDsonTimeSheet.js
+++ b/IDs on Time Sheet/IDsonTimeSheet.js
@@ -16,7 +16,7 @@ tau.mashups
 
                 $target.find('tr.dataRow td:nth-of-type(3) a:first-of-type').each(function(k, v) {
                     var $link = $(v);
-                    var id = $link.attr('href').match(/#(\w+)\/(\d+)/);
+                    var id = $link.attr('href').match(/#(?:page=)?(\w+)\/(\d+)/);
                     if (id) {
                         id = id[2];
                         $link.parent().prepend(


### PR DESCRIPTION
urls format have changed, extraction regex was updated to match old and new version