### PR TITLE
Explicitly set group background in the view menu

### DIFF
--- a/Dark Theme/DarkTheme.js
+++ b/Dark Theme/DarkTheme.js
@@ -45,6 +45,7 @@ tau
             addCSSRule('.tau-board-view .tau-cols-header>ul,.tau-board-grid-view .tau-grid>table', 'border-right: none !important;');
             addCSSRule('.tau-boardclipboard', 'background: #3d424d !important; border: none !important; padding-bottom: 34px !important; bottom: 0px !important;');
             addCSSRule('.t3-views-navigator, .tau-app-main-pane', 'background: #292c33 !important;');
+            addCSSRule('.t3-views-navigator .t3-group', 'background: #292c33 !important;');
             addCSSRule('.tau-app>.tau-app-body>.tau-app-main-pane', 'border-left: 2px solid #14161A !important;');
             addCSSRule('.tau-timeline>.tau-timeline-canvas>.tau-timeline-flow, ._tc-timeline-navigator:before, ._tc-timeline-navigator:after, ._tc-timeline-navigator>.tc-focus-range:before, ._tc-timeline-navigator>.tc-focus-range:after, ._tc-timeline-navigator', 'background: transparent !important;');
             addCSSRule('.t3-views-navigator>.t3-search', 'border: 1px solid #555960 !important;');


### PR DESCRIPTION
When group is being dragged over the menu it has no background color. This is fixed in TargetProcess/TP#5152. However the fix in TP also requires the fix in Dark Theme mashup (this PR)