### PR TITLE
us#171024 replace avatars with library components

### DIFF
--- a/Custom Unit All Assigned People/AllAssignedPeople.js
+++ b/Custom Unit All Assigned People/AllAssignedPeople.js
@@ -6,8 +6,18 @@ tau.mashups
 .addDependency('tau/models/board.customize.units/const.card.sizes')
 .addDependency('tau/models/board.customize.units/board.customize.units.base')
 .addDependency('tau/models/board.customize.units/board.customize.units.interaction')
-.addMashup(function ($, _, globalConfigurator, et, sz, helper, interactionUtils) {
+.addDependency('react')
+.addDependency('react-dom')
+.addDependency('@targetprocess/avatar')
+.addMashup(function ($, _, globalConfigurator, et, sz, helper, interactionUtils, react, reactDOM, avatar) {
     var openUnitEditor = interactionUtils.openUnitEditor.bind(interactionUtils);
+
+    var size = 22;
+    var UnitAvatar = function(url) {
+        var tmp = document.createElement('div');
+        reactDOM.render(react.createElement(avatar['default'], {size: size, url: url + size}, null), tmp);
+        return tmp.innerHTML;
+    };
 
 
     var sampleAssignedUsers = {
@@ -75,9 +85,11 @@ tau.mashups
               '<div class="tau-avatar',
               isResponsible(user) ? '' : ' tau-avatar-not-currentResponsible',
               '">',
-              '<img src="' + user.avatarUri + '20"',
+              '<span',
               settings.isDesignMode ? '' : (' title="' + getUserText(user) + '"'),
               '>',
+              UnitAvatar(user.avatarUri),
+              '</span>',
               '</div>'
             ];
           });

--- a/Custom Unit All Assigned People/AllAssignedPeople.js
+++ b/Custom Unit All Assigned People/AllAssignedPeople.js
@@ -1,143 +1,166 @@
 tau.mashups
-.addDependency('jQuery')
-.addDependency('Underscore')
-.addDependency('tau/configurator')
-.addDependency('tau/models/board.customize.units/const.entity.types.names')
-.addDependency('tau/models/board.customize.units/const.card.sizes')
-.addDependency('tau/models/board.customize.units/board.customize.units.base')
-.addDependency('tau/models/board.customize.units/board.customize.units.interaction')
-.addDependency('react')
-.addDependency('react-dom')
-.addDependency('@targetprocess/avatar')
-.addMashup(function ($, _, globalConfigurator, et, sz, helper, interactionUtils, react, reactDOM, avatar) {
-    var openUnitEditor = interactionUtils.openUnitEditor.bind(interactionUtils);
+    .addDependency('jQuery')
+    .addDependency('Underscore')
+    .addDependency('tau/configurator')
+    .addDependency('tau/models/board.customize.units/const.entity.types.names')
+    .addDependency('tau/models/board.customize.units/const.card.sizes')
+    .addDependency('tau/models/board.customize.units/board.customize.units.base')
+    .addDependency('tau/models/board.customize.units/board.customize.units.interaction')
+    .addDependency('react')
+    .addDependency('react-dom')
+    .addMashup(function ($, _, globalConfigurator, et, sz, helper, interactionUtils, react, reactDOM) {
+        var css = '.avatar__avatar__0-0-6 {border-radius: 50%;background-position: center;background-size: cover;}';
+        var style = document.createElement('style');
+        style.type = 'text/css';
 
-    var size = 22;
-    var UnitAvatar = function(url) {
-        var tmp = document.createElement('div');
-        reactDOM.render(react.createElement(avatar['default'], {size: size, url: url + size}, null), tmp);
-        return tmp.innerHTML;
-    };
+        if (style.styleSheet) {
+            style.styleSheet.cssText = css;
+        } else {
+            style.appendChild(document.createTextNode(css));
+        }
+
+        document.head.appendChild(style);
+
+        var styles = {'avatar': 'avatar__avatar__0-0-6'};
+
+        var Avatar = function Avatar(_ref) {
+            var url = _ref.url,
+                _ref$size = _ref.size,
+                size = _ref$size === undefined ? 36 : _ref$size;
+            return react.createElement('div', {
+                className: styles.avatar,
+                style: { width: size, height: size, backgroundImage: 'url("' + url + '")' }
+            });
+        };
+
+        var openUnitEditor = interactionUtils.openUnitEditor.bind(interactionUtils);
+
+        var size = 22;
+        var UnitAvatar = function(url) {
+            var tmp = document.createElement('div');
+            reactDOM.render(react.createElement(Avatar, {size: size, url: url + size}, null), tmp);
+            return tmp.innerHTML;
+        };
 
 
-    var sampleAssignedUsers = {
-        users: [
-            {
-                id: 1,
-                fullName: 'Uladzimir Karatkievich',
-                email: 'u.karatkievich@writer.com',
-                avatarUri: helper.url('/Javascript/tau/css/images/icons/users/karat.png?size='),
-                isActive: true
-            },
-            {
-                id: 2,
-                fullName: 'Janka Kupala',
-                email: 'ja.kupala@writer.com',
-                avatarUri: helper.url('/Javascript/tau/css/images/icons/users/kupala.png?size='),
-                isActive: true
-            },
-            {
-                id: 3,
-                fullName: 'Adam Mickiewicz',
-                email: 'a.mickiewicz@writer.com',
-                avatarUri: helper.url('/Javascript/tau/css/images/icons/users/mick.png?size='),
-                isActive: true
-            },
-            {
-                id: 4,
-                fullName: 'Uladzimir Karatkievich',
-                email: 'u.karatkievich@writer.com',
-                avatarUri: helper.url('/Javascript/tau/css/images/icons/user.png?size='),
-                isActive: true
+        var sampleAssignedUsers = {
+            users: [
+                {
+                    id: 1,
+                    fullName: 'Uladzimir Karatkievich',
+                    email: 'u.karatkievich@writer.com',
+                    avatarUri: helper.url('/Javascript/tau/css/images/icons/users/karat.png?size='),
+                    isActive: true
+                },
+                {
+                    id: 2,
+                    fullName: 'Janka Kupala',
+                    email: 'ja.kupala@writer.com',
+                    avatarUri: helper.url('/Javascript/tau/css/images/icons/users/kupala.png?size='),
+                    isActive: true
+                },
+                {
+                    id: 3,
+                    fullName: 'Adam Mickiewicz',
+                    email: 'a.mickiewicz@writer.com',
+                    avatarUri: helper.url('/Javascript/tau/css/images/icons/users/mick.png?size='),
+                    isActive: true
+                },
+                {
+                    id: 4,
+                    fullName: 'Uladzimir Karatkievich',
+                    email: 'u.karatkievich@writer.com',
+                    avatarUri: helper.url('/Javascript/tau/css/images/icons/user.png?size='),
+                    isActive: true
+                }
+            ],
+            currentStateResponsiblePersons: [1, 2, 3, 4]
+        };
+        function collectionWithCount(collection, minCount, elementRender) {
+            var result = [];
+            var count = Math.min(collection.length, minCount);
+            for (var i = 0; i < count; i++) {
+                result.push('<div class="tau-board-unit_type_list__item">');
+                result.push(elementRender(collection[i]));
+                result.push('</div>');
             }
-        ],
-        currentStateResponsiblePersons: [1, 2, 3, 4]
-    };
-  function collectionWithCount(collection, minCount, elementRender) {
-    var result = [];
-    var count = Math.min(collection.length, minCount);
-    for (var i = 0; i < count; i++) {
-      result.push('<div class="tau-board-unit_type_list__item">');
-      result.push(elementRender(collection[i]));
-      result.push('</div>');
-    }
-    if (collection.length > minCount) {
-      result.push('<div class="tau-board-unit_type_list__others-counter">');
-      result.push(collection.length - minCount);
-      result.push('</div>');
-    }
-    return _.flatten(result, true).join('');
-  }
-
-  function assignedPeopleTemplate(count) {
-    return {
-      markup : [
-        '<%= fn.assignedPeople(this.data, ' + count + ', this.settings) %>'
-      ],
-      customFunctions : {
-        assignedPeople : function (data, minCount, settings) {
-          var isResponsible = this.isResponsible.bind(this, data);
-          var getUserText = this.getUserText.bind(this);
-          var ordered = this.getPeopleOrdered(data);
-
-          return collectionWithCount(ordered, minCount, function (user) {
-            return [
-              '<div class="tau-avatar',
-              isResponsible(user) ? '' : ' tau-avatar-not-currentResponsible',
-              '">',
-              '<span',
-              settings.isDesignMode ? '' : (' title="' + getUserText(user) + '"'),
-              '>',
-              UnitAvatar(user.avatarUri),
-              '</span>',
-              '</div>'
-            ];
-          });
+            if (collection.length > minCount) {
+                result.push('<div class="tau-board-unit_type_list__others-counter">');
+                result.push(collection.length - minCount);
+                result.push('</div>');
+            }
+            return _.flatten(result, true).join('');
         }
-      }
-    };
-  }
 
-  var units = [
-      {
-        id : 'assigned_users_all',
-        classId : 'tau-board-unit_type_avatars-list',
-        hideIf : function (data) {
-            return !data.users || !data.users.length;
-        },
-        name : 'Assigned people',
-        header : 'Assignments',
-        types : [et.FEATURE, et.EPIC, et.STORY, et.TASK, et.BUG, et.REQUEST, et.TEST_PLAN_RUN],
-        sizes : [sz.M, sz.L, sz.XL, sz.LIST],
-        sections : 1,
-        model : 'users:assignedUser.Select({id,avatarUri,fullName,email}),currentStateResponsiblePersons',
-        template : assignedPeopleTemplate(999),
-        listSettings : {
-            title : '<%= _.map(fn.getPeopleOrdered(this.data), fn.getUserText).join("&#10;") %>'
-        },
-        sampleData : sampleAssignedUsers,
-        interactionConfig : {
-            isEditable : true,
-            handler : openUnitEditor('assignments')
+        function assignedPeopleTemplate(count) {
+            return {
+                markup : [
+                    '<%= fn.assignedPeople(this.data, ' + count + ', this.settings) %>'
+                ],
+                customFunctions : {
+                    assignedPeople : function (data, minCount, settings) {
+                        var isResponsible = this.isResponsible.bind(this, data);
+                        var getUserText = this.getUserText.bind(this);
+                        var ordered = this.getPeopleOrdered(data);
+
+                        return collectionWithCount(ordered, minCount, function (user) {
+                            return [
+                                '<div class="tau-avatar',
+                                isResponsible(user) ? '' : ' tau-avatar-not-currentResponsible',
+                                '">',
+                                '<span',
+                                settings.isDesignMode ? '' : (' title="' + getUserText(user) + '"'),
+                                '>',
+                                UnitAvatar(user.avatarUri),
+                                '</span>',
+                                '</div>'
+                            ];
+                        });
+                    }
+                }
+            };
         }
-    }
-  ];
 
-  function addUnits(configurator) {
-    var registry = configurator.getUnitsRegistry();
-    _.extend(registry.units, registry.register(units));
-  }
+        var units = [
+            {
+                id : 'assigned_users_all',
+                classId : 'tau-board-unit_type_avatars-list',
+                hideIf : function (data) {
+                    return !data.users || !data.users.length;
+                },
+                name : 'Assigned people',
+                header : 'Assignments',
+                types : [et.FEATURE, et.EPIC, et.STORY, et.TASK, et.BUG, et.REQUEST, et.TEST_PLAN_RUN],
+                sizes : [sz.M, sz.L, sz.XL, sz.LIST],
+                sections : 1,
+                model : 'users:assignedUser.Select({id,avatarUri,fullName,email}),currentStateResponsiblePersons',
+                template : assignedPeopleTemplate(999),
+                listSettings : {
+                    title : '<%= _.map(fn.getPeopleOrdered(this.data), fn.getUserText).join("&#10;") %>'
+                },
+                sampleData : sampleAssignedUsers,
+                interactionConfig : {
+                    isEditable : true,
+                    handler : openUnitEditor('assignments')
+                }
+            }
+        ];
 
-  var appConfigurator;
-  globalConfigurator.getGlobalBus().on('configurator.ready', function(e, configurator) {
+        function addUnits(configurator) {
+            var registry = configurator.getUnitsRegistry();
+            _.extend(registry.units, registry.register(units));
+        }
 
-      if (!appConfigurator && configurator._id && configurator._id.match(/board/)) {
+        var appConfigurator;
+        globalConfigurator.getGlobalBus().on('configurator.ready', function(e, configurator) {
 
-          appConfigurator = configurator;
-          addUnits(appConfigurator);
+            if (!appConfigurator && configurator._id && configurator._id.match(/board/)) {
 
-      }
+                appConfigurator = configurator;
+                addUnits(appConfigurator);
 
-  });
+            }
 
-});
+        });
+
+    });


### PR DESCRIPTION
In us#171024, we replace the avatars with the Avatar component from the library throughout the Targetprocess code. This PR makes the avatars generated with Custom Unit All Assigned People mashup consistent with other TP units with avatars.

This update should come to the user with the same TP update that will ship the us#171024 changes.